### PR TITLE
Update item roll patches and flags

### DIFF
--- a/scripts/patches/item-base-roll-patch.mjs
+++ b/scripts/patches/item-base-roll-patch.mjs
@@ -43,21 +43,21 @@ export function patchItemBaseRoll() {
                 checkRoll = await this.rollAttack({ event: capturedModifiers, chatMessage: false });
                 if (checkRoll) {
                     title = _createWeaponTitle(this, checkRoll);
-                    messageData["flags.dnd5e.roll.type"] = "attack";
+                    messageData.flags["dnd5e.roll.type"] = "attack";
                 }
             } else if (this.type === "tool") {
                 expectRoll = true;
                 checkRoll = await this.rollToolCheck({ event: capturedModifiers, chatMessage: false  });
                 if (checkRoll) {
                     title = _createToolTitle(this, checkRoll);
-                    messageData["flags.dnd5e.roll.type"] = "tool";
+                    messageData.flags["dnd5e.roll.type"] = "tool";
                 }
             }
 
             if (checkRoll) {
                 await _replaceAbilityCheckButtonWithRollResult(messageData, this, checkRoll, title);
 
-                messageData["flags.dnd5e.roll.itemId"] = this.id;
+                messageData.flags["dnd5e.roll.itemId"] = this.id;
                 messageData.flavor = undefined;
                 messageData.roll = checkRoll;
                 messageData.type = foundry.CONST.CHAT_MESSAGE_TYPES.ROLL;

--- a/scripts/patches/item-base-roll-patch.mjs
+++ b/scripts/patches/item-base-roll-patch.mjs
@@ -80,7 +80,7 @@ export function patchItemBaseRoll() {
             const options = { event: capturedModifiers, spellLevel };
             if (args.length && Number.isNumeric(args[0].spellLevel)) options.spellLevel = args[0].spellLevel;
             if (checkRoll) {
-                options.critical = checkRoll.results[0] >= checkRoll.terms[0].options.critical;
+                options.critical = checkRoll.dice[0].results[0].result >= checkRoll.terms[0].options.critical;
             }
             await this.rollDamage(options);
         }

--- a/scripts/patches/item-damage-patch.mjs
+++ b/scripts/patches/item-damage-patch.mjs
@@ -204,13 +204,15 @@ async function _createCombinedDamageMessageData(item, content, flavor, rolls, cr
         speaker: ChatMessage.getSpeaker({actor: item.actor}),
         sound: CONFIG.sounds.dice,
         type: foundry.CONST.CHAT_MESSAGE_TYPES.ROLL,
-        "flags.dnd5e.roll": {type: "damage", itemId: item.id },
-        "flags.mre-dnd5e.rolls": rolls.map(r => foundry.utils.deepClone(r)),
+        flags: {
+            ["dnd5e.roll"]: {type: "damage", itemId: item.id },
+            ["mre-dnd5e.rolls"]: rolls.map(r => foundry.utils.deepClone(r)),
+        }
     };
 
     if (critical) {
         messageData.flavor += ` (${game.i18n.localize("DND5E.Critical")})`;
-        messageData["flags.dnd5e.roll"].critical = true;
+        messageData.flags["dnd5e.roll"].critical = true;
     }
 
     ChatMessage.applyRollMode(messageData, rollMode);


### PR DESCRIPTION
Resolves #24 

- Updates the damage workflow to fit new Dice results.
- Fixes flag creation on chat messages.